### PR TITLE
show loading symbol on top of everything

### DIFF
--- a/src/loadingoverlay.js
+++ b/src/loadingoverlay.js
@@ -63,7 +63,8 @@ LoadingOverlay - A flexible loading overlay jQuery plugin
                     "display"           : "flex",
                     "flex-direction"    : "column",
                     "align-items"       : "center",
-                    "justify-content"   : "center"
+                    "justify-content"   : "center",
+                    "z-index" : "9999"
                 }
             });
             if (settings.image) overlay.css({


### PR DESCRIPTION
Loading gif or font awesome icon gets behind any elements also placed there. Adding z-index takes it on top of everything.
