### PR TITLE
fixes z-index issue

### DIFF
--- a/src/loadingoverlay.js
+++ b/src/loadingoverlay.js
@@ -15,7 +15,8 @@ LoadingOverlay - A flexible loading overlay jQuery plugin
         maxSize         : "100px",
         minSize         : "20px",
         resizeInterval  : 0,
-        size            : "50%"
+        size            : "50%",
+        zIndex          : 1
     };
 
     $.LoadingOverlaySetup = function(settings){
@@ -64,7 +65,8 @@ LoadingOverlay - A flexible loading overlay jQuery plugin
                     "display"           : "flex",
                     "flex-direction"    : "column",
                     "align-items"       : "center",
-                    "justify-content"   : "center"
+                    "justify-content"   : "center",
+                    "z-index"           : settings.zIndex
                 }
             });
             if (settings.image) overlay.css({


### PR DESCRIPTION
This adds a default `z-index` of 1 which can be set to any other value by passing a `zIndex` property.

This can be useful if you are using e.g. the jQuery colorbox plugin or anything that makes the overlay invisible.
