### PR TITLE
Bower publishing

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,18 @@
+{
+  "name": "jquery-loading-overlay-gasparesganga",
+  "description": "Flexible loading overlay jQuery Plugin",
+  "homepage": "http://gasparesganga.com/labs/jquery-loading-overlay/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gasparesganga/jquery-loading-overlay.git"
+  },
+  "authors": ["Gaspare Sganga <contact@gasparesganga.com>"],
+  "main": "src/loadingoverlay.js",
+  "moduleType": ["globals"],
+  "keywords": ["jquery", "loading", "overlay"],
+  "dependencies": {
+    "jquery": "~1.0.0"
+  },
+  "ignore": ["**/.*", "node_modules", "bower_components", "package.json", "test", "tests"],
+  "license": "MIT"
+}


### PR DESCRIPTION
**You must publish your package** on Bower (and eventually on npm, RubyGems and any other sort of package manager that people use to manage front-end packages).

Putting it simple: if you don't, people who want to use it will just download and inject it into their project's source code repository. Monkey patches will often happen because they will not create a patch and PR it, because it will be _"just a script they'd downloaded from the Internet."_ You also loose the ability to provide improvements to your users, etc.

So, publishing it to package managers is a must. So, I'm starting the Bower publishing here because that's what I need now (my case: Ruby on Rails app, using RubyGems and proxying some front-end assets through ruby-assets.org), but npm probably should be the next one.

So, they are still tasks for you:
- [x] **Bootstrap a `bower.json`**
- [ ] **Choose a name**  
  `jquery-loading-overlay` is already being used
- [ ] **Double-check the jQuery version dependency**  
  What is the oldest jQuery version your library is compatible with (or you want it to be)?
- [ ] **Are these keywords OK/enough?**
- [ ] **Publish it to the registry (bower.io)**  
  Follow steps from the [Register section](https://bower.io/docs/creating-packages/#register) from Bower's documentation

These are things you must do by your own, since you're the author (and now the maintainer) of the lib, it must be on your  package registries' realm.
