### PR TITLE
Make TypeScript declaration files usable in Node projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         "url": "https://github.com/gasparesganga/jquery-loading-overlay/issues"
     },
     "main": "dist/loadingoverlay.min.js",
+    "types": "typings/loadingoverlay.d.ts",
     "keywords": [
         "ecosystem:jquery",
         "jquery-plugin",


### PR DESCRIPTION
PR #19 added a type declaration file for the library, but didn't add it in a way that TypeScript is able to find per https://www.typescriptlang.org/docs/handbook/module-resolution.html#how-typescript-resolves-modules.

It's likely that in 2017 this was fine, but in 2022 it means code like this:
```TypeScript
import "gasparesganga-jquery-loading-overlay";
```
... will not result in type definitions being included as well, which is annoying.

This commit fixes this by taking the strategy outlined by https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package where `package.json` is updated to point to the declaration file.